### PR TITLE
Switch to experimental component

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -4,7 +4,7 @@
 		"origamiCategory": "components",
 		"origamiVersion": 1,
 		"support": "https://github.com/Financial-Times/n-sliding-popup/issues",
-		"supportStatus": "active",
+		"supportStatus": "experimental",
 		"browserFeatures": {},
 		"ci": {
 			"circle": "https://circleci.com/api/v1/project/Financial-Times/n-sliding-popup"


### PR DESCRIPTION
`n-` components, are usually listed as `experimental` at first, especially if this will be Origami-fied, we'll be able to switch it to `active` in the near future
