### PR TITLE
use new image service

### DIFF
--- a/demos/src/demo.mustache
+++ b/demos/src/demo.mustache
@@ -43,7 +43,7 @@
     </div>
     <div class="Prompt-aside ShownOn-desktop">
       <figure class="Prompt-figure">
-        <img src="https://www.ft.com/__origami/service/image/v2/images/raw/http://next-geebee.ft.com/assets/people/lionel.png?source=test&amp;width=126" alt="Lionel Barber, Editor">
+        <img src="https://www.ft.com/__origami/service/image/v2/images/raw/http://next-geebee.ft.com/assets/people/lionel.png?source=next&amp;width=126" alt="Lionel Barber, Editor">
         <figcaption class="Prompt-figureCaption">Lionel Barber, Editor
       </figcaption></figure>
     </div>

--- a/demos/src/demo.mustache
+++ b/demos/src/demo.mustache
@@ -43,7 +43,7 @@
     </div>
     <div class="Prompt-aside ShownOn-desktop">
       <figure class="Prompt-figure">
-        <img src="https://image.webservices.ft.com/v1/images/raw/http://next-geebee.ft.com/assets/people/lionel.png?source=test&amp;width=126" alt="Lionel Barber, Editor">
+        <img src="https://www.ft.com/__origami/service/image/v2/images/raw/http://next-geebee.ft.com/assets/people/lionel.png?source=test&amp;width=126" alt="Lionel Barber, Editor">
         <figcaption class="Prompt-figureCaption">Lionel Barber, Editor
       </figcaption></figure>
     </div>


### PR DESCRIPTION
We launched the new image service 6 days ago, I'm currently going around FT projects and helping them migrate to it.

The new Image Service includes a lot of improvements:
- The application is multi-region with failover
- We use stale-on-error and stale-while-revalidate cache extensions to ensure users get stale content if the application errors or has to revalidate an image
- We serve much smaller WebP and JPEG XR images to supported browsers
- We’ve seen a reduction in file size for a large number of image requests
- We’re now serving images over H2