### PR TITLE
Set `aria-hidden` to true when popup is closed

### DIFF
--- a/src/js/sliding-popup.js
+++ b/src/js/sliding-popup.js
@@ -20,6 +20,7 @@ class SlidingPopup {
 
 	close () {
 		this.el.removeAttribute('data-n-sliding-popup-visible');
+		this.el.setAttribute('aria-hidden', 'true');
 		const event = new CustomEvent('close', { detail: { target: this.el, instance: this }});
 		if (this.el.onClose) {
 			this.el.onClose.call(null, event);

--- a/src/js/sliding-popup.js
+++ b/src/js/sliding-popup.js
@@ -16,6 +16,7 @@ class SlidingPopup {
 
 	open () {
 		this.el.setAttribute('data-n-sliding-popup-visible', 'true');
+		this.el.setAttribute('aria-hidden', 'false');
 	}
 
 	close () {


### PR DESCRIPTION
Currently when a user closes the popup, it disappears from the screen but is still picked up by the screen reader. This is because all we do is change the popup's opacity and essentially make it invisible when closed. This PR sets `aria-hidden` to true so we don't confuse screen
reader users. The reason why we use `aria-hidden` over `display: none` is because the popup is animated and it would be a lot more complicated to use the later.

DAC ticket: https://trello.com/c/aQqSISwt/160-bleedthrough-issue-id-dacbleedthrough01