### PR TITLE
Update support contact and show demo in registry

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -4,6 +4,10 @@
 		"origamiCategory": "components",
 		"origamiVersion": 1,
 		"support": "https://github.com/Financial-Times/n-sliding-popup/issues",
+		"supportContact": {
+			"email": "accounts-team.customer-products@ft.com",
+			"slack": "financialtimes/customer-products-accounts-team"
+		},
 		"supportStatus": "experimental",
 		"browserFeatures": {},
 		"ci": {

--- a/origami.json
+++ b/origami.json
@@ -23,7 +23,6 @@
 				"name": "demo",
 				"js": "demos/src/demo.js",
 				"template": "demos/src/demo.mustache",
-				"hidden": true,
 				"description": ""
 			}
 		]


### PR DESCRIPTION
- Updates origami.json support contacts to match bizops
- Shows the demo in the registry
<img width="704" alt="Screenshot 2020-05-29 at 11 17 42" src="https://user-images.githubusercontent.com/10405691/83249939-405e1100-a19f-11ea-97bc-fed81b482eeb.png">

Aside: It looks like this component is quite old in style. Maybe something we should look at deprecating?