### PR TITLE
ACC-2348 sorted out the local demo and added instructions on how to run it

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ n-sliding-popup [![Circle CI](https://circleci.com/gh/Financial-Times/n-sliding-
 This is an [origami component](https://registry.origami.ft.com/components/n-sliding-popup@4.0.0). The sliding popup component is maintained by the accounts team. It is designed to allow a wrapped component to slide up from the bottom of the page when triggered, providing an interactive user experience
 ----
 
+## Installation
+Run `npm install`
+
+## Running demo
+Run `npx origami-build-tools dev`. This will serve a demo on localhost, as well as on your network (the output in the terminal will give you the links).
 ## Usage
 
 Create a div that looks like this:

--- a/origami.json
+++ b/origami.json
@@ -2,7 +2,7 @@
 		"description": "Component description",
 		"origamiType": "module",
 		"origamiCategory": "components",
-		"origamiVersion": 1,
+		"origamiVersion": "2.0",
 		"support": "https://github.com/Financial-Times/n-sliding-popup/issues",
 		"supportContact": {
 			"email": "accounts-team.customer-products@ft.com",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8047,7 +8047,9 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "extraneous": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/origami-build-tools/node_modules/js-tokens": {
       "version": "4.0.0",
@@ -26976,7 +26978,9 @@
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
           "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-          "extraneous": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         },
         "js-tokens": {
           "version": "4.0.0",


### PR DESCRIPTION
## Description
The ticket task is to migrate this repo to Storybook - presumably due to broken demo functionality. This raised a number of other questions:
1️⃣  should this be migrated to be a proper origami component?
2️⃣  should this repo be joined with n-live-chat, as that's the only thing that's using this module?
3️⃣  do we need to (and can we) migrate to Storybook given the functionality?

I asked for help in the [origami channel](https://financialtimes.slack.com/archives/C02FU5ARJ/p1682335926007769). I learned that 1️⃣ is a straightforward NO, because a [potential origami component needs to have multiple uses](https://financialtimes.atlassian.net/wiki/spaces/OR/pages/8038383752/Origami+proposals+process). Lee suggested 2️⃣ but after a short discussion at refinement the team parked this idea as something that isn't urgent. In terms of 3️⃣ , Lee offered a suggestion on how to get the demo running locally (alongside a warning that `origami-build-tools` is deprecated). It's also not entirely clear that Storybook would work for this demo as n-sliding-popup is less of a component with many states, but more of set of JavaScript code that waits until the page loads and then opens an unsolicited pop-up (see the video below). 

This PR has instructions on how to run the local demo. 

https://user-images.githubusercontent.com/31079643/234025390-3bd60b82-6f20-4cdd-8f94-b66ba78bfad8.mov

## Ticket
https://financialtimes.atlassian.net/browse/ACC-2348