### PR TITLE
changed origami status to dead

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -8,7 +8,7 @@
 			"email": "accounts-team.customer-products@ft.com",
 			"slack": "financialtimes/customer-products-accounts-team"
 		},
-		"supportStatus": "experimental",
+		"supportStatus": "dead",
 		"browserFeatures": {},
 		"ci": {
 			"circle": "https://circleci.com/api/v1/project/Financial-Times/n-sliding-popup"


### PR DESCRIPTION
Per this instruction https://github.com/Financial-Times/origami/blob/e95f17f9a7be2557ec6d2c37f3fc3b1840f3f5bc/apps/website/_components/versioning.md#deprecate-a-component we need to change the origami.json status